### PR TITLE
🎨 Improved logging and comparing mechanism

### DIFF
--- a/.github/scripts/prefect_deployments.py
+++ b/.github/scripts/prefect_deployments.py
@@ -105,22 +105,22 @@ def get_current_branch() -> str:
     return current_branch
 
 
-def get_commits(current_branch: str) -> List[str]:
+def get_commits(branch: str) -> List[str]:
     """
-    Retrieve the commit hashes of the parent commits involved in a given branch's merge.
+    Retrieves the commit hashes for the given branch.
 
     Args:
-        current_branch (str): The name of the branch to retrieve commit hashes for.
+        branch (str): The name of the branch.
         
     Returns:
-        List[str]: A list of commit hashes for the parent commits of the given branch's merge.
+        List[str]: A list of commit hashes.
     """
     # Get the commit hashes for the given branch
     commit_hashes_command = [
         "git",
         "rev-list",
         "--ancestry-path",
-        f"{current_branch}^..HEAD",
+        f"{branch}^..HEAD",
     ]
     commit_hashes_result = subprocess.run(
         commit_hashes_command, capture_output=True, text=True
@@ -189,28 +189,14 @@ def visit_deployment(
         logger.info(f"Deleting deployment from {path}")
         for deployment in prefect_deployments:
             if file_name in deployment.tags:
-                delete_deployment(str(deployment.id), deployment.name)
+                delete_deployment(str(deployment.id), deployment.name)         
 
-def revert_string_list(string_list: List[str]) -> List[str]:
-    """
-    Reverses the order of strings in a list.
+branch = get_current_branch()
 
-    Args:
-        string_list (List[str]): The list of strings to be reversed.
-
-    Returns:
-        List[str]: The reversed list of strings.
-    """
-    string_list[:] = string_list[::-1]
-    
-    return string_list                
-
-current_branch = get_current_branch()
-
-commits = get_commits(current_branch=current_branch)
+commits = get_commits(branch=branch)
 
 # Reverse the list of commits to ensure operations are performed in the same order as the user did
-inverted_list = revert_string_list(commits)
+inverted_list = reversed(commits)
 
 loop = asyncio.get_event_loop()
 prefect_deployments = loop.run_until_complete(get_prefect_deployments())

--- a/.github/scripts/prefect_deployments.py
+++ b/.github/scripts/prefect_deployments.py
@@ -11,14 +11,21 @@ The script performs the following tasks:
 """
 
 import asyncio
+import logging
 import os
 import subprocess
 from typing import Dict, List
 
 from packaging import version
+
 from prefect import __version__
 from prefect.deployments import Deployment
 from prefect.settings import PREFECT_API_KEY, PREFECT_API_URL
+
+logging.basicConfig()
+logger = logging.getLogger("Automatic Prefect Deployment")
+logger.setLevel(logging.INFO)
+
 
 if version.parse(__version__) >= version.parse("2.10"):
     from prefect.client.orchestration import get_client
@@ -54,11 +61,11 @@ def create_deployment(file_name: str) -> None:
         subprocess.CalledProcessError: If the deployment creation fails.
     """
     try:
-        print(f"Creating deployment {file_name} ...")
+        logger.info(f"Creating deployment {file_name} ...")
         subprocess.run(["python3", file_name], check=True)
-        print(f"Successfully completed {file_name} deployment creation")
+        logger.info(f"Successfully completed {file_name} deployment creation")
     except subprocess.CalledProcessError as e:
-        print(f"FAILED to create deployment {file_name}")
+        logger.warning(f"FAILED to create deployment {file_name}")
         raise e
 
 
@@ -73,23 +80,23 @@ def delete_deployment(deployment_id: str, deployment_name: str) -> None:
         subprocess.CalledProcessError: If the deployment deletion fails.
     """
     try:
-        print(f"Deleting deployment {deployment_name} ...")
+        logger.info(f"Deleting deployment {deployment_name} ...")
         delete_command = ["prefect", "deployment", "delete", "--id", deployment_id]
         subprocess.run(delete_command, capture_output=True, text=True)
-        print(f"Successfully completed {deployment_name} deployment deleting")
+        logger.info(f"Successfully completed {deployment_name} deployment deleting")
     except subprocess.CalledProcessError as e:
-        print(f"FAILED to delete deployment {deployment_name}")
+        logger.warning(f"FAILED to delete deployment {deployment_name}")
         raise e
 
 
 def get_current_branch() -> str:
     """
-    Get the name of the current Git branch.
+    Retrieve the hash of the current branch.
 
     Returns:
-        str: The name of the current branch.
+        str: The hash of the current branch.
     """
-    current_branch_command = ["git", "branch", "--show-current"]
+    current_branch_command = ["git", "rev-parse", "HEAD"]
     current_branch_result = subprocess.run(
         current_branch_command, capture_output=True, text=True
     )
@@ -98,25 +105,22 @@ def get_current_branch() -> str:
     return current_branch
 
 
-def get_commits(main_branch: str, current_branch: str) -> List[str]:
+def get_commits(current_branch: str) -> List[str]:
     """
-    Get the commit hashes between the main branch and the current branch.
+    Retrieve the commit hashes of the parent commits involved in a given branch's merge.
 
     Args:
-        main_branch (str): The name of the main branch.
-        current_branch (str): The name of the current branch.
-
+        current_branch (str): The name of the branch to retrieve commit hashes for.
+        
     Returns:
-        List[str]: A list of commit hashes.
+        List[str]: A list of commit hashes for the parent commits of the given branch's merge.
     """
     # Get the commit hashes for the given branch
     commit_hashes_command = [
         "git",
-        "log",
-        "--no-merges",
-        current_branch,
-        f"^{main_branch}",
-        "--format=%H",
+        "rev-list",
+        "--ancestry-path",
+        f"{current_branch}^..HEAD",
     ]
     commit_hashes_result = subprocess.run(
         commit_hashes_command, capture_output=True, text=True
@@ -176,21 +180,37 @@ def visit_deployment(
         "R",
         "C",
     ]:
-        print(f"Creating deployment from {path}")
+        logger.info(f"Creating deployment from {path}")
         os.chdir("../../prefect/flows/deployments/")
         if os.path.exists(file_name):
             create_deployment(file_name)
 
     elif path.startswith("prefect/flows/deployments/") and operation == "D":
-        print(f"Deleting deployment from {path}")
+        logger.info(f"Deleting deployment from {path}")
         for deployment in prefect_deployments:
             if file_name in deployment.tags:
                 delete_deployment(str(deployment.id), deployment.name)
 
+def revert_string_list(string_list: List[str]) -> List[str]:
+    """
+    Reverses the order of strings in a list.
+
+    Args:
+        string_list (List[str]): The list of strings to be reversed.
+
+    Returns:
+        List[str]: The reversed list of strings.
+    """
+    string_list[:] = string_list[::-1]
+    
+    return string_list                
 
 current_branch = get_current_branch()
 
-commits = get_commits(main_branch="master", current_branch=current_branch)
+commits = get_commits(current_branch=current_branch)
+
+# Reverse the list of commits to ensure operations are performed in the same order as the user did
+inverted_list = revert_string_list(commits)
 
 loop = asyncio.get_event_loop()
 prefect_deployments = loop.run_until_complete(get_prefect_deployments())
@@ -200,7 +220,7 @@ script_directory = os.getcwd()
 visited = []
 
 # Iterate over commit hashes
-for commit in commits:
+for commit in inverted_list:
     modified_files = get_modified_files(commit)
 
     for path, operation in modified_files.items():


### PR DESCRIPTION
The prefect_deployment script has been improved.

In the previous version, the script compared the branch from which the PR was created with the main branch. However, due to the lack of a trigger in GitHub Actions that allows running actions after a PR is accepted, a minor change in the script's functionality was necessary. The GitHub Action is now triggered after changes are pushed to the main branch (only after the PR is accepted), which will cause the previous version of the script to fail since it would compare the main branch with itself and not detect any changes. In the latest version of the script, it examines all commits included between the merge commit and the latest merge commit, allowing it to detect newly added deployments.

Additionally, the script has replaced print statements with logging, and a revert_string_list() function has been added to reverse the list of commits, ensuring that everything is executed in the correct order.